### PR TITLE
comment out outdated microphone calibration menu

### DIFF
--- a/uvk5_egzumer_f4hwn_ver_4_3_0.py
+++ b/uvk5_egzumer_f4hwn_ver_4_3_0.py
@@ -3140,16 +3140,19 @@ class UVK5RadioEgzumer(chirp_common.CloneModeRadio):
             radio_setting = RadioSetting(name, "Off", val)
             radio_setting_group.append(radio_setting)
 
-        radio_setting_group = RadioSettingGroup("mic_calibration",
-                                                "Microphone Sensitivity")
-        calibration.append(radio_setting_group)
+        ## Mic gain values (0-31) are hardcoded in gMicGain_dB2,
+        ## this setting is ignored.
+        ##
+        # radio_setting_group = RadioSettingGroup("mic_calibration",
+        #                                         "Microphone Sensitivity")
+        # calibration.append(radio_setting_group)
 
-        for lvl in range(0, 5):
-            name = "_mem.cal.micLevel[" + str(lvl) + "]"
-            tempval = min_max_def(eval(name), 0, 31, 31)
-            val = RadioSettingValueInteger(0, 31, tempval)
-            radio_setting = RadioSetting(name, "Level " + str(lvl), val)
-            radio_setting_group.append(radio_setting)
+        # for lvl in range(0, 5):
+        #     name = "_mem.cal.micLevel[" + str(lvl) + "]"
+        #     tempval = min_max_def(eval(name), 0, 31, 31)
+        #     val = RadioSettingValueInteger(0, 31, tempval)
+        #     radio_setting = RadioSetting(name, "Level " + str(lvl), val)
+        #     radio_setting_group.append(radio_setting)
 
         radio_setting_group = RadioSettingGroup("other_calibration", "Other")
         calibration.append(radio_setting_group)


### PR DESCRIPTION
microphone sensitivity values are harcoded in `gMicGain_dB2` and the calibration value which is set by this menu item is ignored.